### PR TITLE
CEW-122: remove duplicate fee html from template

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -119,13 +119,6 @@
       {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
     </div>
 
-    {if $priceSet}
-      {if ! $quickConfig}<fieldset id="priceset" class="crm-public-form-item crm-group priceset-group">
-        <legend>{$event.fee_label}</legend>{/if}
-      {include file="CRM/Price/Form/PriceSet.tpl" extends="Event"}
-      {include file="CRM/Price/Form/ParticipantCount.tpl"}
-      {if ! $quickConfig}</fieldset>{/if}
-    {/if}
     {if $pcp && $is_honor_roll }
       <fieldset class="crm-public-form-item crm-group pcp-group">
         <div class="crm-public-form-item crm-section pcp-section">


### PR DESCRIPTION
Issue was that the html that prints fee was used twice in the template. Removed the duplicate html.
