### PR TITLE
BASW-24: Show notice message for access denied when purchase membership button is disabled

### DIFF
--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -242,6 +242,11 @@ function _membersonlyevent_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
     $contactID = CRM_Core_Session::getLoggedInContactID();
     if (!$contactID) {
       _membersonlyevent_add_login_button_to_event_info_page();
+    } else {
+      $membersOnlyEvent = MembersOnlyEvent::getMembersOnlyEvent($eventID);
+      if (!$membersOnlyEvent->purchase_membership_button) {
+        CRM_Core_Session::setStatus($membersOnlyEvent->notice_for_access_denied);
+      }
     }
   }
 }


### PR DESCRIPTION
## Requirements  

For logged in users who neither have "**Can register for members only events irrespective of membership status**" permission nor have any active membership (right now or at the time of event start date depending on the duration check config) with the type that is specified in the "**Allowed Membership Type**" list of the event, the book now button will not appear but a notice button will appear on the top of the page with the content admin provided in "**Notice for access denied**" field.

## Solution

If the access is denied to the event and the user is not logged in, the code will check if purchase_membership_button is enabled for the event, if not then the content of notice_for_access_denied field will be displayed using CRM_Core_Session::setStatus() method.

![222](https://user-images.githubusercontent.com/6275540/33946422-a99713aa-e019-11e7-8945-11b99fb147ca.gif)

