### PR TITLE
BASW-94: Remove Incorrect User Warning Message

### DIFF
--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -272,7 +272,6 @@ function _membersonlyevent_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
   else {
     _membersonlyevent_handle_access_denied_for_logged_users($eventID);
   }
-  CRM_Core_Session::setStatus('You have already registered for this event!');
 }
 
 /**


### PR DESCRIPTION
## Overview ##
On my previous PR(https://github.com/compucorp/uk.co.compucorp.civicrm.members-only-events/pull/30), I have added a user warning message in an incorrect location. This PR removes that warning.