### PR TITLE
BASW-37: Support Members Only Events When Using Event Templates

### DIFF
--- a/api/v3/MembersOnlyEvent.php
+++ b/api/v3/MembersOnlyEvent.php
@@ -42,5 +42,5 @@ function civicrm_api3_members_only_event_delete($params) {
  * @throws API_Exception
  */
 function civicrm_api3_members_only_event_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'MembersOnlyEvent');
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
 }

--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -577,12 +577,14 @@ function _membersonlyevent_add_configurations_menu(&$params) {
 }
 
 /**
- * Returns the DAO name for MembersOnlyEvent
- *
- * @return string
+ * Implements hook_civicrm_entityTypes().
  */
-function _civicrm_api3_members_only_event_DAO() {
-  return 'CRM_MembersOnlyEvent_DAO_MembersOnlyEvent';
+function membersonlyevent_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes[] = [
+    'name'  => 'MembersOnlyEvent',
+    'class' => 'CRM_MembersOnlyEvent_DAO_MembersOnlyEvent',
+    'table' => 'membersonlyevent',
+  ];
 }
 
 /**


### PR DESCRIPTION
## Overview ##
Members only event related settings are not copied over to events when using event templates with members only event settings.

## Approach ##
I have added pre and post hooks to check if an event is created from a template and if has members only event related settings, I am copying it over using api calls (MembersOnlyEvent entity)