### PR TITLE
MAE-334: Fix tab display issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: pull_request
+
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install phpcs
+        run: cd bin && ./install-php-linter
+
+      - name: Fetch target branch
+        run: git fetch -n origin ${GITHUB_BASE_REF}
+
+      - name: Run phpcs linter
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-unit-tests:
+
+    runs-on: ubuntu-latest
+    container: compucorp/civicrm-buildkit:1.0.0
+
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+
+      - name: Config mysql database as per CiviCRM requirement
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
+
+      - name: Build Drupal site
+        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.24.6
+          path: site/web/sites/all/modules/civicrm
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicrm.members-only-events
+
+      - name: Installing Members Only Event extension
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: cv en com.compucorp.membersonlyevent
+
+      - name: Run phpunit tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicrm.members-only-events
+        run: phpunit5

--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -53,7 +53,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
     $this->add(
       'checkbox',
       'is_members_only_event',
-      ts('Is members-only event ?')
+      ts('Only allow members to register for this event?')
     );
 
     $this->addEntityRef(
@@ -212,7 +212,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
       $defaultValues['contribution_page_id'] = $membersOnlyEvent->contribution_page_id;
       $defaultValues['purchase_membership_url'] = $membersOnlyEvent->purchase_membership_url;
     }
-    
+
     return $defaultValues;
   }
 

--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -95,7 +95,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
       ts('Contribution Page'),
       array(
         'entity' => 'ContributionPage',
-        'multiple' => False,
+        'multiple' => FALSE,
         'placeholder' => ts('- Select -'),
         'select' => array('minimumInputLength' => 0),
       )
@@ -130,6 +130,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
       case self::NO_SELECTED:
         $this->validateForDisabledPurchaseButton($values, $errors);
         break;
+
       case self::YES_SELECTED:
         $this->validateForEnabledPurchaseButton($values, $errors);
         break;
@@ -197,12 +198,12 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
    * @inheritdoc
    */
   public function setDefaultValues() {
-    $defaultValues= array();
+    $defaultValues = array();
 
     $this->setInitialValues($defaultValues);
 
     $membersOnlyEvent = MembersOnlyEvent::getMembersOnlyEvent($this->_id);
-    if($membersOnlyEvent) {
+    if ($membersOnlyEvent) {
       $defaultValues['is_members_only_event'] = self::YES_SELECTED;
       $defaultValues['allowed_membership_types'] = EventMembershipType::getAllowedMembershipTypesIDs($membersOnlyEvent->id);
       $defaultValues['purchase_membership_button'] = $membersOnlyEvent->purchase_membership_button;
@@ -239,14 +240,16 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
     $eventSetToMembersOnly = !empty($params['is_members_only_event']) ? self::YES_SELECTED : self::NO_SELECTED;
     $membersOnlyEvent = MembersOnlyEvent::getMembersOnlyEvent($params['event_id']);
     $submitOperation = $this->getSubmitOperation($eventSetToMembersOnly, $membersOnlyEvent);
-    switch ($submitOperation){
+    switch ($submitOperation) {
       case self::OPERATION_CREATE:
         $this->saveFormData($params);
         break;
+
       case self::OPERATION_UPDATE:
         $params['id'] = $membersOnlyEvent->id;
         $this->saveFormData($params);
         break;
+
       case self::OPERATION_DOWNGRADE_TO_NORMAL_EVENT:
         $this->downgradeToNormalEvent($membersOnlyEvent->id);
         break;
@@ -270,7 +273,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
    * @param boolean $eventSetToMembersOnly
    *   True if Is members-only event ?' field is checked
    *   or False if it's not.
-   * @param MembersOnlyEvent $membersOnlyEvent
+   * @param \CRM_MembersOnlyEvent_BAO_MembersOnlyEvent $membersOnlyEvent
    *   Contains the members-only event configurations if the event is
    *   members-only event.
    *
@@ -279,15 +282,15 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
    *   defined at the top of this class.
    */
   private function getSubmitOperation($eventSetToMembersOnly, $membersOnlyEvent = NULL) {
-    if(!$membersOnlyEvent && !$eventSetToMembersOnly) {
+    if (!$membersOnlyEvent && !$eventSetToMembersOnly) {
       return self::OPERATION_DO_NOTHING;
     }
 
-    if($membersOnlyEvent && !$eventSetToMembersOnly) {
+    if ($membersOnlyEvent && !$eventSetToMembersOnly) {
       return self::OPERATION_DOWNGRADE_TO_NORMAL_EVENT;
     }
 
-    if($membersOnlyEvent && $eventSetToMembersOnly) {
+    if ($membersOnlyEvent && $eventSetToMembersOnly) {
       return self::OPERATION_UPDATE;
     }
 
@@ -327,4 +330,5 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
     $membersOnlyEvent->id = $membersOnlyEventID;
     $membersOnlyEvent->delete();
   }
+
 }

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Download PHPCS if it already does not exist
+if [ ! -f phpcs.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+fi
+# Give executable permission to PHPCS
+chmod +x phpcs.phar
+
+# Download PHPCBF if it already does not exist
+if [ ! -f phpcbf.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+fi
+
+# Give executable permission to PHPCBF
+chmod +x phpcbf.phar
+
+# Clone CiviCRM Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
+fi

--- a/css/MembersOnlyEventTab.css
+++ b/css/MembersOnlyEventTab.css
@@ -1,7 +1,3 @@
 .crm-event-manage-membersonlyevent-form-help {
   padding-bottom: 1px;
 }
-
-
-
-

--- a/css/MembersOnlyEventTab.css
+++ b/css/MembersOnlyEventTab.css
@@ -1,0 +1,7 @@
+.crm-event-manage-membersonlyevent-form-help {
+  padding-bottom: 1px;
+}
+
+
+
+

--- a/js/CRM/Form/MembersOnlyEventTab.js
+++ b/js/CRM/Form/MembersOnlyEventTab.js
@@ -22,7 +22,7 @@ jQuery(document).ready(function(){
    * the needed fields.
    */
   function setInitialFieldValues() {
-    toggleMembersOnlyEventFields(membersOnlyEventCheckbox.attr("checked"));
+    toggleMembersOnlyEventFields(membersOnlyEventCheckbox.is(':checked'));
 
     var purchaseMembershipButtonEnabled = jQuery("input[name='purchase_membership_button']:checked").val();
     togglePurchaseButtonFields(purchaseMembershipButtonEnabled);
@@ -36,7 +36,7 @@ jQuery(document).ready(function(){
    */
   function setFieldListeners() {
     membersOnlyEventCheckbox.click(function(){
-      toggleMembersOnlyEventFields(jQuery(this).attr("checked"));
+      toggleMembersOnlyEventFields(jQuery(this).is(':checked'));
     });
 
     jQuery("input[name='purchase_membership_button']").click(function(){

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="PHP Custom Ruleset">
+  <description>CiviCRM Coder Ruleset</description>
+  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal">
+    <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
+    <exclude-pattern>membersonlyevent.civix.php</exclude-pattern>
+  </rule>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="Members only eventsTest Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
+++ b/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
@@ -5,8 +5,11 @@
   </div>
 
   <div class="crm-section">
-    <div class="label">{$form.is_members_only_event.label}</div>
-    <div class="content">{$form.is_members_only_event.html}</div>
+    <div class="label"></div>
+    <div class="content">
+      {$form.is_members_only_event.html}
+      {$form.is_members_only_event.label}
+    </div>
     <div class="clear"></div>
   </div>
 

--- a/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
+++ b/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
@@ -98,3 +98,4 @@
 </script>
 {/literal}
 {crmScript ext="com.compucorp.membersonlyevent" file="js/CRM/Form/MembersOnlyEventTab.js"}
+{crmStyle ext="com.compucorp.membersonlyevent" file="css/MembersOnlyEventTab.css"}

--- a/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
+++ b/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
@@ -1,6 +1,4 @@
-{* Check if the online registration for this event is allowed, show notification message otherwise *}
-<div class="crm-block crm-form-block crm-event-manage-membersonlyevent-form-block">
-{if $isOnlineRegistration == 1}
+<div class="crm-block crm-form-block crm-event-manage-membersonlyevent-form-block" style="display: none;">
   {* HEADER *}
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="top"}
@@ -51,15 +49,52 @@
       </div>
     </div>
   </div>
-</div>
 
   {* FOOTER *}
   <div class="crm-submit-buttons">
-      {include file="CRM/common/formButtons.tpl" location="bottom"}
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
+</div>
+<div class="crm-event-manage-membersonlyevent-form-help">
+  <div class="help">{ts}Online registration tab needs to be enabled first.{/ts}</div>
+</div>
+{literal}
+<script>
+  CRM.$(function($) {
 
-{else}
-  <div id="help">{ts}Online registration tab needs to be enabled first.{/ts}</div>
-{/if}
+    initialPage();
+    eventListner();
 
+    function initialPage() {
+      //Check if the online registration for this event is allowed, show notification message otherwise
+      toggleForm();
+    }
+
+    function eventListner() {
+      $("#tab_membersonlyevent").click(function(){
+        toggleForm();
+      });
+    }
+
+    function toggleForm() {
+      CRM.api3('Event', 'get', {
+        "sequential": 1,
+        "return": ["is_online_registration"],
+        "id": {/literal}{$id}{literal}
+      }).then(function(result) {
+        if (result['values'][0]['is_online_registration'] == 1) {
+          $(".crm-event-manage-membersonlyevent-form-block").show();
+          $(".crm-event-manage-membersonlyevent-form-help").hide();
+          $("#tab_membersonlyevent").removeClass("disabled");
+        }
+        else {
+          $(".crm-event-manage-membersonlyevent-form-block").hide();
+          $(".crm-event-manage-membersonlyevent-form-help").show();
+          $("#tab_membersonlyevent").addClass("disabled");
+        }
+      });
+    }
+  });
+</script>
+{/literal}
 {crmScript ext="com.compucorp.membersonlyevent" file="js/CRM/Form/MembersOnlyEventTab.js"}

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Civi\Test;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * An abstract BaseHeadlessTest class.
+ */
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface, Test\HookInterface {
+
+  /**
+   * Sets up Headless, use stock schema,, install extensions.
+   */
+  public function setUpHeadless() {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * This file is a wrapper to bootstrap cv command.
+ */
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+
+define('CIVICRM_CONTAINER_CACHE', 'never');
+define('CIVICRM_TEST', 1);
+putenv('CIVICRM_UF=' . ($_ENV['CIVICRM_UF'] = 'UnitTests'));
+eval(cv('php:boot --level=settings', 'phpcode'));
+
+if (CIVICRM_UF === 'UnitTests') {
+  Civi\Test::headless()->apply();
+}
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ *
+ * @return string
+ *   Response output (if the command executed normally).
+ *
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/
+      // then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
## Overview
This PR is to fix the tab display issues: 

1. Member only event settings' tab is not enabled immediately after saving Online Registration tab.  It is enabled only after refreshing the page or try opening the event again after 'Save and Done.'

2. When clicked on 'Is Members-only event' checkbox, other configurations for Member only event are still hidden.  We need to save and open the 'Member only event settings' tab again to display other configurations.

And this PR also:

- Update  enable Members only events text.
- Add styling for help text when online registration is not enabled. 
- Add Pull Request templates.
- Add phpcs linters for future use.
- Add phpunit tests skeleton for future use. 

## Before

- Issue before the bug was fix.

![MAE-321- Tab display issue](https://user-images.githubusercontent.com/208713/87022194-0df7f880-c1ce-11ea-8822-f6fdafc48ae7.gif)

- Label before it was updated.

![Screenshot from 2020-07-08 20-43-35](https://user-images.githubusercontent.com/208713/87024760-71375a00-c1d1-11ea-959a-c7bd76fa6b14.png)

- Help test style before it was updated.

![Screenshot from 2020-07-09 10-48-26](https://user-images.githubusercontent.com/208713/87025064-d1c69700-c1d1-11ea-9536-4160cf12e05a.png)



## After

- Screenshot after the bug was fix.

![Peek 2020-07-09 10-35](https://user-images.githubusercontent.com/208713/87023685-fb7ebe80-c1cf-11ea-92f7-9ead3b7162c9.gif)

- Label after it has been updated.

![Screenshot from 2020-07-08 20-53-05](https://user-images.githubusercontent.com/208713/87024723-667cc500-c1d1-11ea-9448-779fecbe6e41.png)

- Help text box after style sheet is added. 

![Screenshot from 2020-07-09 10-24-04](https://user-images.githubusercontent.com/208713/87024795-7dbbb280-c1d1-11ea-9b8a-6302b15b5fde.png)

## Technical Details

Previously members only event tab page was using smarty template logic to check if the online registration is enabled, since the page has already been complied when we navigate between tabs, we would see the same page that have already been complied. 

In order resolve the issue, the solution is to check if the online registration is enabled when Members only event setting tab is clicked and get the result from CiviCRM API. 

```
$("#tab_membersonlyevent").click(function(){
  toggleForm();
});

function toggleForm() {
      CRM.api3('Event', 'get', {
        "sequential": 1,
        "return": ["is_online_registration"],
        "id": {/literal}{$id}{literal}
      }).then(function(result) {
        if (result['values'][0]['is_online_registration'] == 1) {
          $(".crm-event-manage-membersonlyevent-form-block").show();
          $(".crm-event-manage-membersonlyevent-form-help").hide();
          $("#tab_membersonlyevent").removeClass("disabled");
        }
        else {
          $(".crm-event-manage-membersonlyevent-form-block").hide();
          $(".crm-event-manage-membersonlyevent-form-help").show();
          $("#tab_membersonlyevent").addClass("disabled");
        }
      });
 }

```