### PR TITLE
MAE-321: Update version for release

### DIFF
--- a/CRM/MembersOnlyEvent/Upgrader/Base.php
+++ b/CRM/MembersOnlyEvent/Upgrader/Base.php
@@ -39,7 +39,7 @@ class CRM_MembersOnlyEvent_Upgrader_Base {
     if (! self::$instance) {
       // FIXME auto-generate
       self::$instance = new CRM_MembersOnlyEvent_Upgrader(
-        'com.compucorp.membersonlyevent',
+        'uk.co.compucorp.membersonlyevent',
         realpath(__DIR__ .'/../../../')
       );
     }

--- a/info.xml
+++ b/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<extension key="com.compucorp.membersonlyevent" type="module">
+<extension key="uk.co.compucorp.membersonlyevent" type="module">
   <file>membersonlyevent</file>
   <name>Members Only Event</name>
   <description>Allow some events to be accessible only by users with CiviCRM Memberships, you can also allow users with certain membership types to access certain events.</description>
@@ -7,11 +7,11 @@
     <author>Compucorp</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2014-05-23</releaseDate>
-  <version>3.0.0</version>
-  <develStage>alpha</develStage>
+  <releaseDate>2020-08-20</releaseDate>
+  <version>1.0.0</version>
+  <develStage>stable</develStage>
   <compatibility>
-    <ver>4.6, 4.7</ver>
+    <ver>5.24</ver>
   </compatibility>
   <comments>Please report any comments or issues with the module on the Github page for the extension.</comments>
   <civix>

--- a/membersonlyevent.civix.php
+++ b/membersonlyevent.civix.php
@@ -169,7 +169,7 @@ function _membersonlyevent_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'com.compucorp.membersonlyevent';
+        $e['module'] = 'uk.co.compucorp.membersonlyevent';
       }
       $entities[] = $e;
     }
@@ -198,7 +198,7 @@ function _membersonlyevent_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'com.compucorp.membersonlyevent',
+      'module' => 'uk.co.compucorp.membersonlyevent',
       'name' => $name,
       'file' => $file,
     );


### PR DESCRIPTION
## Overview

This PR is for update info.xml to release a new Members only event extension version 1.0.0 

This PR is also including the update of extension key. 

## Before
Extension key was defined as com.compucorp.membersonlyevent

## After
New extension key will be defined as uk.co.compucorp.membersonlyevent 
